### PR TITLE
Fix unpublished npm package "meklog"

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"axios": "^1.6.3",
 		"discord.js": "^14.14.1",
 		"dotenv": "^16.3.1",
-		"meklog": "^1.0.2"
+		"meklog": "git+https://github.com/mekb-turtle/log.git"
 	},
 	"type": "module",
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"axios": "^1.6.3",
 		"discord.js": "^14.14.1",
 		"dotenv": "^16.3.1",
-		"meklog": "git+https://github.com/mekb-turtle/log.git"
+		"meklog": "git+https://github.com/mekb-turtle/log.git#58288f283b0337d19b682028b1609d003e3bb221"
 	},
 	"type": "module",
 	"devDependencies": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched the logging dependency source from the npm registry to a specific Git repository commit.
  * No other dependencies or public interfaces were modified.
  * Package installation may require Git access or allow fetching Git-based dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->